### PR TITLE
fix: gate AUTO_SCAN_PAGE behind user settings with rate limiting

### DIFF
--- a/google extension/background.js
+++ b/google extension/background.js
@@ -227,6 +227,24 @@ Return EXACTLY:
   }
 }
 
+// ─── Auto-scan deduplication cache ─────────────────────────
+const recentScans = new Map(); // url -> timestamp
+const SCAN_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+
+function isRecentlyScanned(url) {
+  const last = recentScans.get(url);
+  return last && (Date.now() - last) < SCAN_COOLDOWN_MS;
+}
+
+function markScanned(url) {
+  recentScans.set(url, Date.now());
+  // Prevent unbounded growth
+  if (recentScans.size > 100) {
+    const oldest = [...recentScans.entries()].sort((a, b) => a[1] - b[1])[0][0];
+    recentScans.delete(oldest);
+  }
+}
+
 // ─── Domain Reputation Quick Check ─────────────────────────
 const KNOWN_SAFE = new Set([
   "google.com", "youtube.com", "github.com", "wikipedia.org", "stackoverflow.com",
@@ -335,25 +353,46 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           return currentScan;
 
         case "AUTO_SCAN_PAGE":
-          console.log(`[Guardian] 🔄 Auto-scanning page:`, msg.title);
+          console.log(`[Guardian] 🔄 Auto-scan requested for:`, msg.title);
           try {
-            // Analyze based on page type
+            // Read user settings before doing anything
+            const settings = await new Promise(resolve => {
+              chrome.storage.sync.get(['autoScan', 'autoPrivacy', 'paymentVerify'], resolve);
+            });
+
+            if (!settings.autoScan) {
+              console.log(`[Guardian] ⏭️ Auto-scan is disabled by user — skipping`);
+              return { skipped: true, reason: "autoScan disabled" };
+            }
+
+            // Deduplication: skip if this URL was scanned recently
+            if (isRecentlyScanned(msg.url)) {
+              console.log(`[Guardian] ⏭️ URL scanned recently — skipping:`, msg.url);
+              const cached = await new Promise(resolve => {
+                chrome.storage.local.get(['currentPageScan'], r => resolve(r.currentPageScan || null));
+              });
+              return cached || { skipped: true, reason: "recently scanned" };
+            }
+
+            markScanned(msg.url);
+
+            // Analyze based on page type and user settings
             let privacy = null, payment = null;
-            
-            if (msg.isPrivacy) {
+
+            if (msg.isPrivacy && settings.autoPrivacy) {
               privacy = await analyzePrivacyPolicy(msg.text, msg.url, msg.title);
               if (privacy.riskScore > 60) await incrementStat("threatsFound");
             }
-            
-            if (msg.isPayment) {
+
+            if (msg.isPayment && settings.paymentVerify) {
               payment = await verifyPaymentGateway(msg.url, msg.text);
               if (payment.score > 50) await incrementStat("threatsFound");
             }
-            
-            // Always do general scan
+
+            // General scan (always runs when autoScan is on)
             const general = await scanPage(msg.url, msg.text, msg.title);
             await incrementStat("pagesScanned");
-            
+
             const summary = {
               url: msg.url,
               title: msg.title,
@@ -365,12 +404,12 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
               isPayment: msg.isPayment,
               overallScore: privacy ? (100 - privacy.riskScore) : (general?.safetyScore || 50)
             };
-            
+
             // Store current page scan
             await new Promise(resolve => {
               chrome.storage.local.set({ currentPageScan: summary }, resolve);
             });
-            
+
             console.log(`[Guardian] ✅ Auto-scan complete:`, summary);
             return summary;
           } catch (err) {

--- a/google extension/content.js
+++ b/google extension/content.js
@@ -326,9 +326,18 @@
         // Gmail
         initGmailScanner();
 
-        // AUTO-SCAN: Always scan every page for the popup dashboard
+        // AUTO-SCAN: Only scan if user has enabled it in settings
         setTimeout(async () => {
             try {
+                // Check user preference before firing any API call
+                const settings = await new Promise(resolve => {
+                    chrome.storage.sync.get(['autoScan'], resolve);
+                });
+                if (!settings.autoScan) {
+                    console.log('[Guardian] ⏭️ Auto-scan disabled — skipping');
+                    return;
+                }
+
                 const pageText = getPageText(8000);
                 const url = location.href;
                 const title = document.title;


### PR DESCRIPTION
- content.js: read autoScan from chrome.storage.sync before sending AUTO_SCAN_PAGE — skips entirely if user hasn't opted in
- background.js: read autoScan, autoPrivacy, paymentVerify settings before executing any AI call in AUTO_SCAN_PAGE handler
- background.js: add in-memory deduplication cache (5 min cooldown) to prevent re-scanning the same URL on soft navigations/tab switches
- background.js: conditionally call analyzePrivacyPolicy only when autoPrivacy is enabled, verifyPaymentGateway only when paymentVerify is enabled — reduces max calls from 3 to 1 per page by default