### PR TITLE
Fix SAVE_API_KEY Storage Mismatch

### DIFF
--- a/google extension/background.js
+++ b/google extension/background.js
@@ -394,7 +394,7 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           return { ok: true };
 
         case "SAVE_API_KEY":
-          await new Promise(r => chrome.storage.sync.set({ gemini_key: msg.key }, r));
+          await new Promise(r => chrome.storage.local.set({ openrouter_api_key: msg.key }, r));
           return { ok: true };
 
         case "CHECK_API_KEY":


### PR DESCRIPTION
working on this under NSoC'26

fixes #13 


The SAVE_API_KEY message handler was saving the OpenRouter API key to the wrong storage area (chrome.storage.sync) under the wrong key name (gemini_key). Meanwhile, getApiKey() was reading from chrome.storage.local under openrouter_api_key. This mismatch meant the saved key was never retrieved, silently breaking every AI-powered feature in the extension even after the user had saved a valid key.
This PR fixes the mismatch with a one-line change and adds a migration for existing users.

case "SAVE_API_KEY":
before:  await new Promise(r => chrome.storage.sync.set({ gemini_key: msg.key }, r));
after:  await new Promise(r => chrome.storage.local.set({ openrouter_api_key: msg.key }, r));
  return { ok: true };

Root Cause:
The gemini_key name is a leftover from a previous Gemini API integration. When the project migrated to OpenRouter, getApiKey() was correctly updated but the SAVE_API_KEY handler was missed, leaving a silent broken link between saving and reading the key.