### PR TITLE
feat: add GitHub Actions workflow to auto-apply NSOC'26 label to new issues

### DIFF
--- a/.github/workflows/auto-label-nsoc26.yml
+++ b/.github/workflows/auto-label-nsoc26.yml
@@ -1,0 +1,22 @@
+name: Auto-label NSoC'26 Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add NSOC'26 label to new issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['NSoC\'26']
+            })


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically applies the NSOC'26 label to newly opened issues.

Tested on issue #2, and the label was applied successfully.

Fixes #32