### PR TITLE
 remove hardcoded Gemini API key

### DIFF
--- a/google extension/HACKATHON_DEMO_README.md
+++ b/google extension/HACKATHON_DEMO_README.md
@@ -28,7 +28,7 @@
 2. **Go to `chrome://extensions/`**
 3. **Enable "Developer mode"** (top right)
 4. **Click "Load unpacked"** and select this folder
-5. ✅ Extension loads with API key pre-configured!
+5. ✅ Extension loads and prompts for your Gemini API key.
 
 ### Running the Demo
 
@@ -71,9 +71,9 @@
 
 ## 🔑 API Key Information
 
-- **Pre-configured API Key:** `AIzaSyD-Id2Kz8PBUu6BT5RLEgYXKB6_ePdPQJw`
-- **Auto-saves on first load**
-- **No manual setup needed**
+- **API Key Required:** enter your own Gemini API key in the extension setup screen
+- **Stored locally in Chrome extension storage**
+- **No shared or pre-configured key is bundled**
 - **Uses Google Gemini 2.0 Flash AI**
 
 ---
@@ -91,8 +91,8 @@
 ## 🎯 Hackathon Winning Features
 
 ✨ **Fully Automated**
-- No API key entry needed
-- Auto-setup on first run
+- User-provided API key setup
+- Local-only key storage
 - Ready to demo immediately
 
 ✨ **Real AI Integration**

--- a/google extension/background.js
+++ b/google extension/background.js
@@ -6,8 +6,14 @@
 const VERSION = "2.0.0";
 const API_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions';
 const MODEL = 'gemini-2.0-flash';
+const API_KEY_STORAGE_KEY = "guardian_gemini_api_key";
+
 async function getApiKey() {
-  return "AIzaSyD-Id2Kz8PBUu6BT5RLEgYXKB6_ePdPQJw";
+  return new Promise(resolve => {
+    chrome.storage.local.get([API_KEY_STORAGE_KEY], r => {
+      resolve(r[API_KEY_STORAGE_KEY] || "");
+    });
+  });
 }
 // ─── Stat counters (persisted in storage) ───────────────────
 async function getStats() {
@@ -45,7 +51,7 @@ async function incrementStat(key, amount = 1) {
 async function callAI(systemPrompt, userContent, maxTokens = 800) {
   const apiKey = await getApiKey();
   if (!apiKey) {
-    throw new Error("No API key set. Please add your OpenRouter API key in the extension settings.");
+    throw new Error("No API key set. Please add your Gemini API key in the extension settings.");
   }
 
   const combinedPrompt = `${systemPrompt}\n\n${userContent}`;
@@ -72,7 +78,7 @@ async function callAI(systemPrompt, userContent, maxTokens = 800) {
     const errorMsg = err.error?.message || `API Error ${res.status}`;
     console.error(`[Guardian] ❌ API Error:`, errorMsg);
     if (res.status === 401 || res.status === 403 || errorMsg.includes('User not found')) {
-      throw new Error('Invalid API key — please update your OpenRouter API key in background.js');
+      throw new Error('Invalid API key — please update your Gemini API key in the extension settings.');
     }
     throw new Error(errorMsg);
   }
@@ -284,13 +290,13 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   const key = await getApiKey();
   if (!key) {
     return { 
-      error: "No API key found. Please set your OpenRouter API key in extension settings.",
+      error: "No API key found. Please set your Gemini API key in extension settings.",
       safetyScore: 0,
       category: "Unknown",
       threats: [],
       goodPoints: [],
       humanSummary: "Scan could not run — API key is missing.",
-      advice: "Please add your OpenRouter API key in the extension settings."
+      advice: "Please add your Gemini API key in the extension settings."
     };
   }
   await incrementStat("pagesScanned");
@@ -390,11 +396,20 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           return { ok: true };
 
         case "SAVE_API_KEY":
-          await new Promise(r => chrome.storage.local.set({ openrouter_api_key: msg.key }, r));
+          await new Promise(r => chrome.storage.local.set({ [API_KEY_STORAGE_KEY]: msg.key }, r));
+          return { ok: true };
+
+        case "CLEAR_API_KEY":
+          await new Promise(r => chrome.storage.local.remove(API_KEY_STORAGE_KEY, r));
           return { ok: true };
 
         case "CHECK_API_KEY":
-          return { hasKey: true, provider: "openrouter" };
+          const storedKey = await getApiKey();
+          return {
+            hasKey: !!storedKey,
+            provider: "gemini",
+            keySuffix: storedKey ? storedKey.slice(-4) : ""
+          };
 
         default:
           console.log(`[Guardian] ⚠️ Unknown message type:`, msg.type);

--- a/google extension/popup.html
+++ b/google extension/popup.html
@@ -971,7 +971,7 @@
         style="color:#818cf8">Google Gemini AI</strong>. Enter your free Gemini API key to activate full AI features.
     </p>
     <div class="field-group" style="text-align:left">
-      <label class="field-label">OpenAI API Key</label>
+      <label class="field-label">Google Gemini API Key</label>
       <input id="setup-key" type="password" class="field-input" placeholder="AIzaSy…" autocomplete="off">
     </div>
     <button id="setup-save" class="btn btn-primary" style="margin-bottom:12px">

--- a/google extension/popup.js
+++ b/google extension/popup.js
@@ -130,6 +130,7 @@ async function showMainApp() {
     $("main-app").classList.remove("hidden");
     await loadStats();
     await loadPageInfo();
+    await refreshApiKeyState();
 }
 
 $("setup-save")?.addEventListener("click", async () => {
@@ -451,7 +452,7 @@ $("analyze-email-btn")?.addEventListener("click", async () => {
 // ─── Settings Logic ───────────────────────────────────────────
 async function loadSettings() {
     return new Promise(resolve => {
-        chrome.storage.sync.get(["gemini_key", "privacyLevel", "adsEnabled", "trackersEnabled", "autoConsent", "paymentVerify", "autoPrivacy", "linkHighlight"], prefs => {
+        chrome.storage.sync.get(["privacyLevel", "adsEnabled", "trackersEnabled", "autoConsent", "paymentVerify", "autoPrivacy", "linkHighlight"], prefs => {
             // Privacy level
             if ($("privacy-level")) $("privacy-level").value = prefs.privacyLevel || "strict";
             // Toggles
@@ -461,13 +462,20 @@ async function loadSettings() {
                 const el = document.querySelector(`[data-key="${key}"]`);
                 if (el) el.classList.toggle("on", val);
             });
-            // Mask key in settings
-            if ($("settings-key") && prefs.gemini_key) {
-                $("settings-key").placeholder = "AIza…" + prefs.gemini_key.slice(-4) + " (saved)";
-            }
             resolve(prefs);
         });
     });
+}
+
+async function refreshApiKeyState() {
+    const keyState = await sendBg({ type: "CHECK_API_KEY" });
+    if ($("settings-key")) {
+        $("settings-key").placeholder = keyState.hasKey
+            ? `AIza…${keyState.keySuffix} (saved)`
+            : "AIza…";
+    }
+    if ($("ai-coverage")) $("ai-coverage").textContent = keyState.hasKey ? "Active (Gemini)" : "No Key";
+    if ($("ai-bar")) $("ai-bar").style.width = keyState.hasKey ? "100%" : "0%";
 }
 
 async function saveSettings() {
@@ -511,6 +519,7 @@ $("save-key-btn")?.addEventListener("click", async () => {
 // Clear key
 $("clear-key-btn")?.addEventListener("click", async () => {
     if (!confirm("Are you sure you want to clear your API key and reset all settings?")) return;
+    await sendBg({ type: "CLEAR_API_KEY" });
     await new Promise(r => chrome.storage.sync.clear(r));
     location.reload();
 });
@@ -519,4 +528,5 @@ $("clear-key-btn")?.addEventListener("click", async () => {
 (async () => {
     await checkSetup();
     await loadSettings();
+    await refreshApiKeyState();
 })();

--- a/google extension/popup.js
+++ b/google extension/popup.js
@@ -521,6 +521,12 @@ $("clear-key-btn")?.addEventListener("click", async () => {
     if (!confirm("Are you sure you want to clear your API key and reset all settings?")) return;
     await sendBg({ type: "CLEAR_API_KEY" });
     await new Promise(r => chrome.storage.sync.clear(r));
+    await new Promise(r => chrome.storage.local.remove([
+        "apiKey",
+        "stats",
+        "currentPageScan",
+        "guardianPaused"
+    ], r));
     location.reload();
 });
 


### PR DESCRIPTION
Before this fix, the extension had a Gemini API key directly written inside `background.js`.

Example of the old problem:

- `getApiKey()` always returned the same hardcoded Gemini key.
- Even if a user entered their own API key in settings, the extension did not actually use it properly.
- `CHECK_API_KEY` always said a key exists, even when the user had not saved any key.
- Clearing the key from settings did not fully stop AI scans from depending on the bundled key.

This was a security risk because the bundled key was exposed publicly in the repository and should be treated as compromised.

## What I Changed

- Removed the hardcoded Gemini API key from `background.js`.
- Added one shared storage key for Gemini API key handling.
- Updated `SAVE_API_KEY` to save the user-provided key in Chrome local storage.
- Updated `CHECK_API_KEY` to return true only when a real saved key exists.
- Updated `CLEAR_API_KEY` so the saved key is properly removed.
- Updated the setup/settings UI text to clearly ask for a Google Gemini API key.
- Updated demo documentation to remove references to a pre-configured API key.

## After Fix

Now, AI scans only run when the user provides their own Gemini API key.

Example flow after the fix:

User loads extension
→ extension asks for Google Gemini API key
→ user saves their own key
→ key is stored locally in Chrome storage
→ AI scans use that saved user key


## If no key is saved
AI scan shows a missing API key message
Instead of using any hidden bundled key.


Author: @goyaljiiiiii 
Reference issue : #47 
