### PR TITLE
fix: make AI auto-scans opt-in

### DIFF
--- a/google extension/HACKATHON_DEMO_README.md
+++ b/google extension/HACKATHON_DEMO_README.md
@@ -28,7 +28,7 @@
 2. **Go to `chrome://extensions/`**
 3. **Enable "Developer mode"** (top right)
 4. **Click "Load unpacked"** and select this folder
-5. ✅ Extension loads with API key pre-configured!
+5. ✅ Extension loads and prompts for your Gemini API key.
 
 ### Running the Demo
 
@@ -71,9 +71,9 @@
 
 ## 🔑 API Key Information
 
-- **Pre-configured API Key:** `AIzaSyD-Id2Kz8PBUu6BT5RLEgYXKB6_ePdPQJw`
-- **Auto-saves on first load**
-- **No manual setup needed**
+- **API Key Required:** enter your own Gemini API key in the extension setup screen
+- **Stored locally in Chrome extension storage**
+- **No shared or pre-configured key is bundled**
 - **Uses Google Gemini 2.0 Flash AI**
 
 ---
@@ -91,8 +91,8 @@
 ## 🎯 Hackathon Winning Features
 
 ✨ **Fully Automated**
-- No API key entry needed
-- Auto-setup on first run
+- User-provided API key setup
+- Local-only key storage
 - Ready to demo immediately
 
 ✨ **Real AI Integration**

--- a/google extension/background.js
+++ b/google extension/background.js
@@ -6,8 +6,14 @@
 const VERSION = "2.0.0";
 const API_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions';
 const MODEL = 'gemini-2.0-flash';
+const API_KEY_STORAGE_KEY = "guardian_gemini_api_key";
+
 async function getApiKey() {
-  return "AIzaSyD-Id2Kz8PBUu6BT5RLEgYXKB6_ePdPQJw";
+  return new Promise(resolve => {
+    chrome.storage.local.get([API_KEY_STORAGE_KEY], r => {
+      resolve(r[API_KEY_STORAGE_KEY] || "");
+    });
+  });
 }
 // ─── Stat counters (persisted in storage) ───────────────────
 async function getStats() {
@@ -45,7 +51,7 @@ async function incrementStat(key, amount = 1) {
 async function callAI(systemPrompt, userContent, maxTokens = 800) {
   const apiKey = await getApiKey();
   if (!apiKey) {
-    throw new Error("No API key set. Please add your OpenRouter API key in the extension settings.");
+    throw new Error("No API key set. Please add your Gemini API key in the extension settings.");
   }
 
   const combinedPrompt = `${systemPrompt}\n\n${userContent}`;
@@ -72,7 +78,7 @@ async function callAI(systemPrompt, userContent, maxTokens = 800) {
     const errorMsg = err.error?.message || `API Error ${res.status}`;
     console.error(`[Guardian] ❌ API Error:`, errorMsg);
     if (res.status === 401 || res.status === 403 || errorMsg.includes('User not found')) {
-      throw new Error('Invalid API key — please update your OpenRouter API key in background.js');
+      throw new Error('Invalid API key — please update your Gemini API key in the extension settings.');
     }
     throw new Error(errorMsg);
   }
@@ -284,13 +290,13 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   const key = await getApiKey();
   if (!key) {
     return { 
-      error: "No API key found. Please set your OpenRouter API key in extension settings.",
+      error: "No API key found. Please set your Gemini API key in extension settings.",
       safetyScore: 0,
       category: "Unknown",
       threats: [],
       goodPoints: [],
       humanSummary: "Scan could not run — API key is missing.",
-      advice: "Please add your OpenRouter API key in the extension settings."
+      advice: "Please add your Gemini API key in the extension settings."
     };
   }
   await incrementStat("pagesScanned");
@@ -390,11 +396,20 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           return { ok: true };
 
         case "SAVE_API_KEY":
-          await new Promise(r => chrome.storage.local.set({ openrouter_api_key: msg.key }, r));
+          await new Promise(r => chrome.storage.local.set({ [API_KEY_STORAGE_KEY]: msg.key }, r));
+          return { ok: true };
+
+        case "CLEAR_API_KEY":
+          await new Promise(r => chrome.storage.local.remove(API_KEY_STORAGE_KEY, r));
           return { ok: true };
 
         case "CHECK_API_KEY":
-          return { hasKey: true, provider: "openrouter" };
+          const storedKey = await getApiKey();
+          return {
+            hasKey: !!storedKey,
+            provider: "gemini",
+            keySuffix: storedKey ? storedKey.slice(-4) : ""
+          };
 
         default:
           console.log(`[Guardian] ⚠️ Unknown message type:`, msg.type);

--- a/google extension/content.js
+++ b/google extension/content.js
@@ -26,6 +26,32 @@
         return (document.body?.innerText || "").slice(0, maxLen);
     }
 
+    function getAutomationPrefs() {
+        return new Promise(resolve => {
+            chrome.storage.sync.get(["autoPrivacy", "paymentVerify", "emailScan"], prefs => {
+                resolve({
+                    autoPrivacy: prefs.autoPrivacy === true,
+                    paymentVerify: prefs.paymentVerify === true,
+                    emailScan: prefs.emailScan === true
+                });
+            });
+        });
+    }
+
+    function isSensitivePage() {
+        const hostname = location.hostname.replace(/^www\./, "").toLowerCase();
+        const sensitiveHosts = [
+            "mail.google.com",
+            "docs.google.com",
+            "drive.google.com",
+            "sheets.google.com",
+            "accounts.google.com",
+            "calendar.google.com"
+        ];
+        const sensitivePath = /account|bank|statement|medical|health/i;
+        return sensitiveHosts.includes(hostname) || sensitivePath.test(location.href);
+    }
+
     // ─── 1. Privacy Policy Auto-Detect ────────────────────────
     const PRIVACY_KEYWORDS = [
         /privacy\s*policy/i, /terms\s*(of\s*service|and\s*conditions)/i,
@@ -328,27 +354,38 @@
         // Link highlighting
         setTimeout(highlightSuspiciousLinks, 2000);
 
-        // Gmail
-        initGmailScanner();
+        const automationPrefs = await getAutomationPrefs();
 
-        // AUTO-SCAN: Always scan every page for the popup dashboard
+        // Gmail email bodies are sensitive, so scanning requires explicit opt-in.
+        if (automationPrefs.emailScan) {
+            initGmailScanner();
+        }
+
+        // AUTO-SCAN: run only for explicitly enabled page categories.
         setTimeout(async () => {
             try {
-                const pageText = getPageText(8000);
                 const url = location.href;
                 const title = document.title;
                 const privacyPage = isPrivacyPage();
-                const paymentPage = isPaymentPage();
+                const shouldScanPrivacy = automationPrefs.autoPrivacy && privacyPage;
+                const shouldScanPayment = automationPrefs.paymentVerify && isPaymentPage();
 
-                console.log('[Guardian] 🔄 Auto-scanning:', title, '(privacy:', privacyPage, 'payment:', paymentPage, ')');
+                if ((!shouldScanPrivacy && !shouldScanPayment) || isSensitivePage()) {
+                    console.log('[Guardian] Auto-scan skipped: no opt-in category or sensitive page.');
+                    return;
+                }
+
+                const pageText = getPageText(8000);
+
+                console.log('[Guardian] 🔄 Auto-scanning:', title, '(privacy:', shouldScanPrivacy, 'payment:', shouldScanPayment, ')');
 
                 const result = await send({
                     type: 'AUTO_SCAN_PAGE',
                     url: url,
                     title: title,
                     text: pageText,
-                    isPrivacy: privacyPage,
-                    isPayment: paymentPage
+                    isPrivacy: shouldScanPrivacy,
+                    isPayment: shouldScanPayment
                 });
 
                 console.log('[Guardian] ✅ Auto-scan complete for:', title);

--- a/google extension/manifest.json
+++ b/google extension/manifest.json
@@ -22,7 +22,7 @@
         "service_worker": "background.js"
     },
     "action": {
-        "default_popup": "popup_simple.html",
+        "default_popup": "popup.html",
         "default_title": "Guardian AI Shield",
         "default_icon": {
             "16": "icons/icon16.png",

--- a/google extension/popup.html
+++ b/google extension/popup.html
@@ -1257,16 +1257,23 @@
           <div class="toggle-row">
             <div>
               <div class="toggle-label">Payment Verification</div>
-              <div class="toggle-sub">Verify checkout pages automatically</div>
+              <div class="toggle-sub">Send checkout page text to AI automatically</div>
             </div>
-            <div class="toggle-switch on" id="toggle-payment" data-key="paymentVerify"></div>
+            <div class="toggle-switch" id="toggle-payment" data-key="paymentVerify"></div>
           </div>
           <div class="toggle-row">
             <div>
               <div class="toggle-label">Auto Privacy Analysis</div>
-              <div class="toggle-sub">Scan privacy policies automatically</div>
+              <div class="toggle-sub">Send policy page text to AI automatically</div>
             </div>
-            <div class="toggle-switch on" id="toggle-privacy-auto" data-key="autoPrivacy"></div>
+            <div class="toggle-switch" id="toggle-privacy-auto" data-key="autoPrivacy"></div>
+          </div>
+          <div class="toggle-row">
+            <div>
+              <div class="toggle-label">Automatic Email Scan</div>
+              <div class="toggle-sub">Send Gmail message text to AI automatically</div>
+            </div>
+            <div class="toggle-switch" id="toggle-email-scan" data-key="emailScan"></div>
           </div>
           <div class="toggle-row">
             <div>

--- a/google extension/popup.html
+++ b/google extension/popup.html
@@ -971,7 +971,7 @@
         style="color:#818cf8">Google Gemini AI</strong>. Enter your free Gemini API key to activate full AI features.
     </p>
     <div class="field-group" style="text-align:left">
-      <label class="field-label">OpenAI API Key</label>
+      <label class="field-label">Google Gemini API Key</label>
       <input id="setup-key" type="password" class="field-input" placeholder="AIzaSy…" autocomplete="off">
     </div>
     <button id="setup-save" class="btn btn-primary" style="margin-bottom:12px">

--- a/google extension/popup.html
+++ b/google extension/popup.html
@@ -1182,11 +1182,12 @@
       <!-- ─── EMAIL TAB ─── -->
       <div class="panel" id="tab-email">
         <div class="card-title" style="margin-bottom:8px">📧 Email Scam Detector</div>
-        <p class="text-small" style="margin-bottom:14px;color:var(--text-muted)">On Gmail, Guardian AI auto-scans your
-          emails. Or paste email content below.</p>
+        <p class="text-small" style="margin-bottom:14px;color:var(--text-muted)">Analyze Gmail messages only after
+          enabling email scan, or paste email content below.</p>
         <div class="alert alert-info">
           <span class="alert-icon">ℹ️</span>
-          <span>Open an email on Gmail and Guardian AI will automatically analyze it for phishing patterns.</span>
+          <span>Automatic Gmail analysis is off by default and only runs after you enable Automatic Email Scan in
+            settings.</span>
         </div>
         <div class="field-group">
           <label class="field-label">Paste email content here</label>

--- a/google extension/popup.js
+++ b/google extension/popup.js
@@ -130,6 +130,7 @@ async function showMainApp() {
     $("main-app").classList.remove("hidden");
     await loadStats();
     await loadPageInfo();
+    await refreshApiKeyState();
 }
 
 $("setup-save")?.addEventListener("click", async () => {
@@ -451,7 +452,7 @@ $("analyze-email-btn")?.addEventListener("click", async () => {
 // ─── Settings Logic ───────────────────────────────────────────
 async function loadSettings() {
     return new Promise(resolve => {
-        chrome.storage.sync.get(["gemini_key", "privacyLevel", "adsEnabled", "trackersEnabled", "autoConsent", "paymentVerify", "autoPrivacy", "linkHighlight"], prefs => {
+        chrome.storage.sync.get(["privacyLevel", "adsEnabled", "trackersEnabled", "autoConsent", "paymentVerify", "autoPrivacy", "linkHighlight"], prefs => {
             // Privacy level
             if ($("privacy-level")) $("privacy-level").value = prefs.privacyLevel || "strict";
             // Toggles
@@ -461,13 +462,20 @@ async function loadSettings() {
                 const el = document.querySelector(`[data-key="${key}"]`);
                 if (el) el.classList.toggle("on", val);
             });
-            // Mask key in settings
-            if ($("settings-key") && prefs.gemini_key) {
-                $("settings-key").placeholder = "AIza…" + prefs.gemini_key.slice(-4) + " (saved)";
-            }
             resolve(prefs);
         });
     });
+}
+
+async function refreshApiKeyState() {
+    const keyState = await sendBg({ type: "CHECK_API_KEY" });
+    if ($("settings-key")) {
+        $("settings-key").placeholder = keyState.hasKey
+            ? `AIza…${keyState.keySuffix} (saved)`
+            : "AIza…";
+    }
+    if ($("ai-coverage")) $("ai-coverage").textContent = keyState.hasKey ? "Active (Gemini)" : "No Key";
+    if ($("ai-bar")) $("ai-bar").style.width = keyState.hasKey ? "100%" : "0%";
 }
 
 async function saveSettings() {
@@ -511,6 +519,7 @@ $("save-key-btn")?.addEventListener("click", async () => {
 // Clear key
 $("clear-key-btn")?.addEventListener("click", async () => {
     if (!confirm("Are you sure you want to clear your API key and reset all settings?")) return;
+    await sendBg({ type: "CLEAR_API_KEY" });
     await new Promise(r => chrome.storage.sync.clear(r));
     location.reload();
 });
@@ -519,4 +528,5 @@ $("clear-key-btn")?.addEventListener("click", async () => {
 (async () => {
     await checkSetup();
     await loadSettings();
+    await refreshApiKeyState();
 })();

--- a/google extension/popup.js
+++ b/google extension/popup.js
@@ -450,15 +450,17 @@ $("analyze-email-btn")?.addEventListener("click", async () => {
 });
 
 // ─── Settings Logic ───────────────────────────────────────────
+const SETTINGS_TOGGLES = ["adsEnabled", "trackersEnabled", "autoConsent", "paymentVerify", "autoPrivacy", "emailScan", "linkHighlight"];
+const AI_AUTOMATION_TOGGLES = new Set(["paymentVerify", "autoPrivacy", "emailScan"]);
+
 async function loadSettings() {
     return new Promise(resolve => {
-        chrome.storage.sync.get(["privacyLevel", "adsEnabled", "trackersEnabled", "autoConsent", "paymentVerify", "autoPrivacy", "linkHighlight"], prefs => {
+        chrome.storage.sync.get(["privacyLevel", ...SETTINGS_TOGGLES], prefs => {
             // Privacy level
             if ($("privacy-level")) $("privacy-level").value = prefs.privacyLevel || "strict";
             // Toggles
-            const toggles = ["adsEnabled", "trackersEnabled", "autoConsent", "paymentVerify", "autoPrivacy", "linkHighlight"];
-            toggles.forEach(key => {
-                const val = prefs[key] !== false; // default ON
+            SETTINGS_TOGGLES.forEach(key => {
+                const val = AI_AUTOMATION_TOGGLES.has(key) ? prefs[key] === true : prefs[key] !== false;
                 const el = document.querySelector(`[data-key="${key}"]`);
                 if (el) el.classList.toggle("on", val);
             });
@@ -481,10 +483,9 @@ async function refreshApiKeyState() {
 async function saveSettings() {
     const prefs = {};
     prefs.privacyLevel = $("privacy-level")?.value || "strict";
-    const toggles = ["adsEnabled", "trackersEnabled", "autoConsent", "paymentVerify", "autoPrivacy", "linkHighlight"];
-    toggles.forEach(key => {
+    SETTINGS_TOGGLES.forEach(key => {
         const el = document.querySelector(`[data-key="${key}"]`);
-        prefs[key] = el ? el.classList.contains("on") : true;
+        prefs[key] = el ? el.classList.contains("on") : !AI_AUTOMATION_TOGGLES.has(key);
     });
     await new Promise(r => chrome.storage.sync.set(prefs, r));
 }

--- a/google extension/popup.js
+++ b/google extension/popup.js
@@ -529,5 +529,4 @@ $("clear-key-btn")?.addEventListener("click", async () => {
 (async () => {
     await checkSetup();
     await loadSettings();
-    await refreshApiKeyState();
 })();


### PR DESCRIPTION
Stopped the extension from automatically sending page or Gmail text to AI by default. Auto privacy, payment, and email scans now require explicit settings opt-in, with sensitive pages skipped.

Author: @goyaljiiiiii
Reference issue: #49 
