### PR TITLE
Issue 3 scan UI fix

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Harsh Mahadik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/google extension/background.js
+++ b/google extension/background.js
@@ -286,23 +286,33 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
           return email;
 
         case "SCAN_PAGE":
-  console.log(`[Guardian] 📄 Starting page scan...`);
-  const key = await getApiKey();
-  if (!key) {
-    return { 
-      error: "No API key found. Please set your Gemini API key in extension settings.",
-      safetyScore: 0,
-      category: "Unknown",
-      threats: [],
-      goodPoints: [],
-      humanSummary: "Scan could not run — API key is missing.",
-      advice: "Please add your Gemini API key in the extension settings."
-    };
-  }
-  await incrementStat("pagesScanned");
-  const scan = await scanPage(msg.url, msg.text, msg.title);
-  console.log(`[Guardian] ✅ Page scan complete:`, scan);
-  return scan;
+          console.log(`[Guardian] 📄 Starting page scan...`);
+          const key = await getApiKey();
+          if (!key) {
+            return { 
+              error: "No API key found. Please set your Gemini API key in extension settings.",
+              safetyScore: 0,
+              category: "Unknown",
+              threats: [],
+              goodPoints: [],
+              humanSummary: "Scan could not run — API key is missing.",
+              advice: "Please add your Gemini API key in the extension settings."
+            };
+          }
+          await incrementStat("pagesScanned");
+          const scan = await scanPage(msg.url, msg.text, msg.title);
+          const scanSummary = {
+            url: msg.url,
+            title: msg.title || 'Unknown Page',
+            timestamp: Date.now(),
+            general: scan,
+            isPrivacy: false,
+            isPayment: false,
+            overallScore: scan.safetyScore || 50
+          };
+          await new Promise(resolve => chrome.storage.local.set({ currentPageScan: scanSummary }, resolve));
+          console.log(`[Guardian] ✅ Page scan complete:`, scan);
+          return scan;
 
         case "ANALYZE_PAGE":
           console.log(`[Guardian] 📋 Starting page analysis...`);

--- a/google extension/popup.html
+++ b/google extension/popup.html
@@ -1123,15 +1123,16 @@
           </div>
         </div>
 
-        <button class="btn btn-secondary" id="reset-stats-btn">🔄 Reset Statistics</button>
-      </div>
+        <div class="card" id="last-scan-card" style="display:none;">
+          <div class="card-title">🕒 Last Scan Summary</div>
+          <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:10px;">
+            <div style="font-weight:700;"><span id="last-scan-title">No scan yet</span></div>
+            <span class="tag tag-green" id="last-scan-badge" style="background:rgba(16,185,129,.12);color:#10b981;border:1px solid rgba(16,185,129,.25);">Safe</span>
+          </div>
+          <div style="font-size:12px;color:var(--text-muted);margin-bottom:8px;" id="last-scan-time">—</div>
+          <div style="font-size:13px;color:var(--text-dim);line-height:1.5;" id="last-scan-summary">Your most recent page scan will appear here after you run an AI scan.</div>
+        </div>
 
-      <!-- ─── SCANNER TAB ─── -->
-      <div class="panel" id="tab-scanner">
-        <div class="card-title" style="margin-bottom:12px">🔍 AI Page Scanner</div>
-        <p class="text-small" style="margin-bottom:14px;color:var(--text-muted)">Guardian AI will analyze this page for
-          security risks, scam patterns, and privacy violations in real time.</p>
-        <button class="btn btn-primary" id="scan-page-btn">
           <span>🧠</span> Run Full AI Scan
         </button>
         <button class="btn btn-secondary mt-8" id="highlight-links-btn">

--- a/google extension/popup.js
+++ b/google extension/popup.js
@@ -85,6 +85,88 @@ function buildTags(items, cls = "tag-amber") {
     return `<div style="margin-top:8px">${items.map(t => `<span class="tag ${cls}">⚡ ${t}</span>`).join("")}</div>`;
 }
 
+function parseApiResponse(resp) {
+    if (!resp) return resp;
+    if (resp.candidates?.[0]?.content?.parts?.[0]?.text) {
+        try {
+            return JSON.parse(resp.candidates[0].content.parts[0].text.trim());
+        } catch (e) {
+            console.warn('API parse fallback failed:', e);
+        }
+    }
+    if (typeof resp === 'string') {
+        try {
+            return JSON.parse(resp.trim());
+        } catch (e) {
+            console.warn('API parse fallback failed:', e);
+        }
+    }
+    return resp;
+}
+
+function displayScanResult(result) {
+    if (!result || result.error) {
+        $("scan-result").innerHTML = `<div class="alert alert-warning"><span class="alert-icon">⚠️</span><span>${result?.error || 'Unable to load scan results.'}</span></div>`;
+        $("scan-result").classList.remove("hidden");
+        return;
+    }
+
+    const color = scoreToColor(result.safetyScore);
+    $("scan-result").innerHTML = `
+      <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px">
+        <span style="font-size:28px">${result.safetyScore >= 70 ? "✅" : result.safetyScore >= 45 ? "⚠️" : "🚨"}</span>
+        <div>
+          <div style="font-weight:700;font-size:15px">${result.category}</div>
+          <div style="font-size:11px;color:var(--text-dim)">AI Scan Complete</div>
+        </div>
+        <div style="margin-left:auto;font-size:26px;font-weight:900;color:${color}">${result.safetyScore}</div>
+      </div>
+      ${buildRiskBar(100 - result.safetyScore, "Risk Level")}
+      <p style="font-size:13px;color:var(--text-muted);margin:10px 0;line-height:1.6">${result.humanSummary || ''}</p>
+      ${result.threats?.length ? `<div style="margin-bottom:8px"><div class="card-title" style="margin-bottom:6px">⚠️ Threats Found</div>${buildTags(result.threats, "tag-red")}</div>` : ""}
+      ${result.goodPoints?.length ? `<div><div class="card-title" style="margin-bottom:6px">✅ Good Signs</div>${buildTags(result.goodPoints, "tag-green")}</div>` : ""}
+      ${result.advice ? `<div class="alert alert-info" style="margin-top:12px"><span class="alert-icon">💡</span><span>${result.advice}</span></div>` : ""}
+    `;
+    $("scan-result").classList.remove("hidden");
+}
+
+function renderLastScanCard(scan) {
+    if (!scan || !scan.url) {
+        $("last-scan-card").style.display = "none";
+        return;
+    }
+
+    const score = scan.overallScore || scan.general?.safetyScore || 0;
+    const verdict = score >= 70 ? "Safe" : score >= 40 ? "Moderate" : "High Risk";
+    const badgeColor = score >= 70 ? "#10b981" : score >= 40 ? "#f59e0b" : "#ef4444";
+    const date = new Date(scan.timestamp || Date.now()).toLocaleString();
+    $("last-scan-title").textContent = scan.title || new URL(scan.url).hostname;
+    $("last-scan-badge").textContent = `${verdict} • ${Math.round(score)}/100`;
+    $("last-scan-badge").style.background = `${badgeColor}22`;
+    $("last-scan-badge").style.color = badgeColor;
+    $("last-scan-time").textContent = `Scanned on ${date}`;
+    $("last-scan-summary").textContent = scan.general?.humanSummary || scan.summary || 'The latest scan summary will appear here.';
+    $("last-scan-card").style.display = "block";
+}
+
+async function loadCurrentScan() {
+    try {
+        const current = await sendBg({ type: "GET_CURRENT_SCAN" });
+        if (!current || current.error) {
+            renderLastScanCard(null);
+            return;
+        }
+        renderLastScanCard(current);
+        const tab = await getActiveTab();
+        if (current.url !== tab.url) return;
+        const scan = current.general || current;
+        if (!scan) return;
+        displayScanResult(scan);
+    } catch (_) {
+        renderLastScanCard(null);
+    }
+}
+
 // ─── Tab Routing ─────────────────────────────────────────────
 const tabs = document.querySelectorAll(".nav-tab");
 const panels = document.querySelectorAll(".panel");
@@ -130,6 +212,7 @@ async function showMainApp() {
     $("main-app").classList.remove("hidden");
     await loadStats();
     await loadPageInfo();
+    await loadCurrentScan();
     await refreshApiKeyState();
 }
 
@@ -260,25 +343,12 @@ $("scan-page-btn")?.addEventListener("click", async () => {
         });
 
         if (result.error) throw new Error(result.error);
-
-        const color = scoreToColor(result.safetyScore);
-        $("scan-result").innerHTML = `
-      <div style="display:flex;align-items:center;gap:10px;margin-bottom:12px">
-        <span style="font-size:28px">${result.safetyScore >= 70 ? "✅" : result.safetyScore >= 45 ? "⚠️" : "🚨"}</span>
-        <div>
-          <div style="font-weight:700;font-size:15px">${result.category}</div>
-          <div style="font-size:11px;color:var(--text-dim)">AI Scan Complete</div>
-        </div>
-        <div style="margin-left:auto;font-size:26px;font-weight:900;color:${color}">${result.safetyScore}</div>
-      </div>
-      ${buildRiskBar(100 - result.safetyScore, "Risk Level")}
-      <p style="font-size:13px;color:var(--text-muted);margin:10px 0;line-height:1.6">${result.humanSummary}</p>
-      ${result.threats?.length ? `<div style="margin-bottom:8px"><div class="card-title" style="margin-bottom:6px">⚠️ Threats Found</div>${buildTags(result.threats, "tag-red")}</div>` : ""}
-      ${result.goodPoints?.length ? `<div><div class="card-title" style="margin-bottom:6px">✅ Good Signs</div>${buildTags(result.goodPoints, "tag-green")}</div>` : ""}
-      ${result.advice ? `<div class="alert alert-info" style="margin-top:12px"><span class="alert-icon">💡</span><span>${result.advice}</span></div>` : ""}
-    `;
+        displayScanResult(result);
+        await loadStats();
+        await loadCurrentScan();
     } catch (err) {
         $("scan-result").innerHTML = `<div class="alert alert-warning"><span class="alert-icon">⚠️</span><span>${err.message === "NO_API_KEY" ? "Set your API key in Settings to enable AI scanning." : "Error: " + err.message}</span></div>`;
+        $("scan-result").classList.remove("hidden");
     }
 });
 
@@ -294,6 +364,7 @@ $("highlight-links-btn")?.addEventListener("click", async () => {
 async function displayPrivacyResult(result, containerId = "privacy-result") {
     if (result.error) {
         $(containerId).innerHTML = `<div class="alert alert-warning"><span class="alert-icon">⚠️</span><span>${result.error === "NO_API_KEY" ? "Set your API key in Settings first." : result.error}</span></div>`;
+        $(containerId).classList.remove("hidden");
         return;
     }
     const color = scoreToColor(result.riskScore, true);
@@ -322,12 +393,13 @@ $("analyze-policy-btn")?.addEventListener("click", async () => {
     try {
         const tab = await getActiveTab();
         const content = await sendContent(tab.id, { type: "GET_PAGE_TEXT" });
-        const result = await sendBg({
+        const rawResult = await sendBg({
             type: "ANALYZE_PRIVACY_POLICY",
             text: content.text,
             url: tab.url,
             title: content.title
         });
+        const result = parseApiResponse(rawResult);
         displayPrivacyResult(result);
     } catch (err) {
         $("privacy-result").innerHTML = `<div class="alert alert-danger"><span class="alert-icon">❌</span><span>${err.message}</span></div>`;
@@ -339,12 +411,13 @@ $("analyze-pasted-btn")?.addEventListener("click", async () => {
     if (!text) { alert("Please paste some policy text first."); return; }
     showLoading("privacy-result", "Analyzing pasted text…");
     try {
-        const result = await sendBg({
+        const rawResult = await sendBg({
             type: "ANALYZE_PRIVACY_POLICY",
             text,
             url: "manual-paste",
             title: "Pasted Policy"
         });
+        const result = parseApiResponse(rawResult);
         displayPrivacyResult(result);
     } catch (err) {
         $("privacy-result").innerHTML = `<div class="alert alert-danger"><span class="alert-icon">❌</span><span>${err.message}</span></div>`;


### PR DESCRIPTION
Closes #3  

## Program
Under Nexus Spring of Code 2026 (NSoC'26)


## What I Changed

> Fixed the scan popup flow so manual scan results now render correctly in the UI
> Persisted the latest page scan in [chrome.storage.local](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) so the popup can show the current scan state
> Added parsing for Gemini-style AI responses, improving reliability for privacy analysis output
>Fixed privacy analyzer result rendering so errors and parsed summaries appear properly
> Added a new dashboard card: Last Scan 

## Summary

> Shows page title
> Shows result badge and score
> Shows scan timestamp
> Shows the latest AI summary

## Why this Matters

> Previously the extension could scan pages in the background but fail to display results to the user
> Now users get visible feedback immediately after pressing Scan This Page Now
> The dashboard now keeps a persistent summary of the latest scan for the current page

