### PR TITLE
Simplify make_icons.py

### DIFF
--- a/google extension/make_icons.py
+++ b/google extension/make_icons.py
@@ -1,67 +1,72 @@
 """
-Generate TrustLayer AI PNG icons for Chrome extension.
-Uses only Python standard library (struct + zlib).
+Generate minimal PNG icons for the Chrome extension.
+Uses only Python standard library: struct + zlib.
 """
-import struct, zlib, os
 
-def make_png(size, color_bg=(0,0,0), color_fg=(255,255,255)):
-    """
-    Creates a minimal valid PNG: black bg, white 'T' shape.
-    Returns raw PNG bytes.
-    """
-    # Build raw RGBA pixel rows
+import os
+import struct
+import zlib
+
+
+def make_png(size, color_bg=(0, 0, 0), color_fg=(255, 255, 255)):
+    stem_width = max(1, size // 10)
+    cx = size // 2
+    stem_x1, stem_x2 = cx - stem_width, cx + stem_width
+    stem_y1, stem_y2 = size // 3, size - size // 4
+    bar_x1, bar_x2 = size // 5, size - size // 5
+    bar_y1, bar_y2 = size // 5, size // 3
+
     rows = []
     for y in range(size):
-        row = []
+        row = bytearray(b"\x00")  # filter type 0
         for x in range(size):
-            # Draw a 'T' shape in the center
-            cx = size // 2
-            # Stem: vertical bar
-            stem_x1 = cx - max(1, size // 10)
-            stem_x2 = cx + max(1, size // 10)
-            stem_y1 = size // 3
-            stem_y2 = size - size // 4
+            is_foreground = (
+                stem_x1 <= x <= stem_x2 and stem_y1 <= y <= stem_y2
+            ) or (
+                bar_x1 <= x <= bar_x2 and bar_y1 <= y <= bar_y2
+            )
+            row.extend(color_fg if is_foreground else color_bg)
+            row.append(255)
+        rows.append(bytes(row))
 
-            # Cross bar: horizontal bar at top
-            bar_x1 = size // 5
-            bar_x2 = size - size // 5
-            bar_y1 = size // 5
-            bar_y2 = size // 3
-
-            in_stem = (stem_x1 <= x <= stem_x2 and stem_y1 <= y <= stem_y2)
-            in_bar  = (bar_x1  <= x <= bar_x2  and bar_y1  <= y <= bar_y2)
-
-            if in_stem or in_bar:
-                row += list(color_fg) + [255]
-            else:
-                row += list(color_bg) + [255]
-        rows.append(bytes([0] + row))  # filter byte = 0 (None)
-
-    raw = b''.join(rows)
-    compressed = zlib.compress(raw, 9)
+    compressed = zlib.compress(b"".join(rows), 9)
 
     def chunk(name, data):
-        c = struct.pack('>I', len(data)) + name + data
-        return c + struct.pack('>I', zlib.crc32(name + data) & 0xffffffff)
+        packed = struct.pack(
+            ">I", len(data)
+        ) + name + data
+        return packed + struct.pack(
+            ">I", zlib.crc32(name + data) & 0xFFFFFFFF
+        )
 
-    png  = b'\x89PNG\r\n\x1a\n'
-    png += chunk(b'IHDR', struct.pack('>IIBBBBB', size, size, 8, 2, 0, 0, 0))
-    # color type 2 = RGB... let's use RGBA (color type 6)
-    # Redo IHDR with color type 6 (RGBA)
-    png  = b'\x89PNG\r\n\x1a\n'
-    png += chunk(b'IHDR', struct.pack('>IIBBBBB', size, size, 8, 6, 0, 0, 0))
-    png += chunk(b'IDAT', compressed)
-    png += chunk(b'IEND', b'')
+    png = b"\x89PNG\r\n\x1a\n"
+    png += chunk(
+        b"IHDR",
+        struct.pack(
+            ">IIBBBBB",
+            size,
+            size,
+            8,
+            6,
+            0,
+            0,
+            0,
+        ),
+    )
+    png += chunk(b"IDAT", compressed)
+    png += chunk(b"IEND", b"")
     return png
 
-out_dir = r"D:\HARSH\New folder\google extension\icons"
-os.makedirs(out_dir, exist_ok=True)
 
-for sz in [16, 48, 128]:
-    data = make_png(sz)
-    path = os.path.join(out_dir, f"icon{sz}.png")
-    with open(path, 'wb') as f:
-        f.write(data)
-    print(f"Created {path} ({len(data)} bytes)")
+if __name__ == "__main__":
+    out_dir = os.path.join(os.path.dirname(__file__), "icons")
+    os.makedirs(out_dir, exist_ok=True)
 
-print("All icons created successfully!")
+    for size in (16, 48, 128):
+        path = os.path.join(out_dir, f"icon{size}.png")
+        with open(path, "wb") as file:
+            file.write(make_png(size))
+        print(f"Created {path} ({os.path.getsize(path)} bytes)")
+
+    print("All icons created successfully!")
+


### PR DESCRIPTION
Pull Request Description
Summary
Simplify the google extension/make_icons.py icon generator by removing duplicated PNG header logic, tightening the pixel row construction, and making output path generation relative to the script location.

Changes
Consolidated PNG chunk creation into a single reusable helper
Switched to RGBA output with correct IHDR color type
Moved shape geometry calculations outside the per-pixel loop
Used [bytearray](vscode-file://vscode-app/c:/Users/Anusha%20ts/AppData/Local/Programs/Microsoft%20VS%20Code/f6cfa2ea24/resources/app/out/vs/code/electron-browser/workbench/workbench.html) for cleaner row assembly
Replaced hardcoded output directory with