### PR TITLE
🎨 UI Fix: Center Guardian AI popup in viewport

### DIFF
--- a/google extension/popup_simple.html
+++ b/google extension/popup_simple.html
@@ -4,7 +4,9 @@
 <meta charset="UTF-8">
 <style>
 * { margin:0; padding:0; box-sizing:border-box; }
-body { width:420px; min-height:500px; background:#0a0a1a; color:#e0e0e0; font-family:'Segoe UI',system-ui,sans-serif; font-size:13px; }
+body { min-height: 100vh; background:#0a0a1a; color:#e0e0e0; font-family:'Segoe UI',system-ui,sans-serif; font-size:13px; display: flex;
+  justify-content: center;       
+  align-items: center;   }
 
 .header { background:linear-gradient(135deg,#6366f1,#8b5cf6); padding:16px; text-align:center; }
 .header h1 { font-size:20px; color:#fff; } .header p { font-size:11px; color:rgba(255,255,255,.8); margin-top:2px; }
@@ -68,9 +70,20 @@ body { width:420px; min-height:500px; background:#0a0a1a; color:#e0e0e0; font-fa
 .slider:before { position: absolute; content: ""; height: 14px; width: 14px; left: 3px; bottom: 3px; background-color: #aaa; transition: .4s; border-radius: 50%; }
 input:checked + .slider { background-color: #ef4444; border-color: #ef4444; }
 input:checked + .slider:before { transform: translateX(18px); background-color: #fff; }
+.app-container {
+  width: 420px;
+  min-height: 500px;
+  background: #0a0a1a;
+  border-radius: 12px;
+  overflow: hidden;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.6); 
+}
+
 </style>
 </head>
 <body>
+
+     <div class="app-container">
 
 <div class="header">
     <h1>🛡️ Guardian AI</h1>
@@ -153,5 +166,6 @@ input:checked + .slider:before { transform: translateX(18px); background-color: 
 </div>
 
 <script src="popup_simple.js"></script>
+</div>
 </body>
 </html>


### PR DESCRIPTION
## Related Issue
Closes #58 

## Summary
Centered the Guardian AI popup interface in the viewport using flexbox.  
Removed fixed width from `<body>` and applied width only to `.app-container` for proper alignment.

## Changes Made
- [x] Updated body CSS to use `display:flex; justify-content:center; align-items:center;`
- [x] Removed fixed width from `<body>`
- [x] Applied fixed width and styling to `.app-container`
- [x] Added optional shadow for better visual polish

## Technical Details & Scope
- **Component Category:** Layout/UI
- **Impact Radius:** Guardian AI popup only

## Testing & Verification
1. **Local Test Command:** `npm run dev`
2. **Browsers Checked:** Chrome, Firefox, Edge
3. **Responsive Verification:** Tested centering on desktop and mobile

## Screenshots
# Before
<img width="1903" height="854" alt="Screenshot 2026-05-30 192454" src="https://github.com/user-attachments/assets/75ba362e-7cb6-4c1e-9e85-2a30132f7b45" />

# After
<img width="1504" height="818" alt="Screenshot 2026-05-30 194612" src="https://github.com/user-attachments/assets/c8bee2a4-cf0a-488f-bfac-9b77d1a5810e" />


## Checklist
- [x] Code follows project conventions and style guidelines
- [x] Tested locally and confirmed all quality gates pass
- [x] No unrelated changes or debug statements included
- [x] Component metadata version and changelog updated if necessary
